### PR TITLE
Fixed source install

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,6 @@
 
 Source Install:
+     $ make
      $ sudo make install
 
 Building and installing a Debian package:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ podget.7.gz: DOC/podget.7
 changelog.gz: Changelog
 	gzip -9 < $< > $@
 
-install: podget podget.7.gz
+install: all
 	mkdir -p $(DESTDIR)$(prefix)/bin/
 	install -m 755 podget $(DESTDIR)$(prefix)/bin/podget
 


### PR DESCRIPTION
Currently, starting from a clean source dir `sudo make install` fails because `changelog.gz` does not exist and is not listed as a dependency for the install target. The patch fixes the Makefile to have the missing dependency.

It also updates the install instruction to first do `make` and then `sudo make install`, which would not be necessary with the patched Makefile, but avoids having generated files in the source dir with root as owner. 