### PR TITLE
Make opml import favor xmlUrl over htmlUrl

### DIFF
--- a/podget
+++ b/podget
@@ -2823,7 +2823,7 @@ if [[ -n ${IMPORT_OPML+set} ]]; then
             fi
 
             new_label=$(echo "${data}" | sed -n -e 's/.*text="\([^"]\+\)".*/\1/Ip' | sed -e 's/^\s*[0-9]\+\.\s\+//' -e "s/[:;'\".,!/?<>\\|]//g")
-            new_url=$(echo "${data}" | sed -n -e 's/.*[xml]*url="\([^"]\+\)".*/\1/Ip' | sed -e 's/ /%20/g')
+            new_url=$(echo "${data}" | sed -n -e 's/.*\(xml\|\W\)url="\([^"]\+\)".*/\2/Ip' | sed -e 's/ /%20/g')
 
             if (( VERBOSITY >= 3 )) ; then
                 echo "LABEL:  ${new_label}"

--- a/podget
+++ b/podget
@@ -1142,8 +1142,7 @@ PLAYLIST_ConvertToASX() {
 
      # Removing unix2dos dependency. Converting to sed statement with in-place editing of the file in question.
      # ctrl-v ctrl-m for windows line end.
-     sed -i 's/$/
-/' "${DIR_LIBRARY}"/"${ASX_PLAYLISTNAME}"
+     sed -i 's/$/^M/' "${DIR_LIBRARY}"/"${ASX_PLAYLISTNAME}"
 }
 
 PLAYLIST_Sort() {

--- a/podget
+++ b/podget
@@ -336,7 +336,7 @@ ASX_PLAYLIST=0
 # to normalize files to have the same volume.
 #
 # A period (.) will automatically be added between the filename and tag like so:
-#       fileanme.mp3.newtag
+#       filename.mp3.newtag
 #
 # Tags will not be added to filenames as they are added to the playlists.  It will be necessary for any script that you run to
 # process the files remove the tag for the playlists to work.
@@ -1142,7 +1142,8 @@ PLAYLIST_ConvertToASX() {
 
      # Removing unix2dos dependency. Converting to sed statement with in-place editing of the file in question.
      # ctrl-v ctrl-m for windows line end.
-     sed -i 's/$//' "${DIR_LIBRARY}"/"${ASX_PLAYLISTNAME}"
+     sed -i 's/$/
+/' "${DIR_LIBRARY}"/"${ASX_PLAYLISTNAME}"
 }
 
 PLAYLIST_Sort() {


### PR DESCRIPTION
When importing this opml file: 

```
<?xml version='1.0' encoding='UTF-8' standalone='no' ?>
<opml version="2.0">
  <head>
    <title>AntennaPod Subscriptions</title>
    <dateCreated>17 Apr 17 12:52:03 +0200</dateCreated>
  </head>
  <body>
    <outline text="Developer Tea" title="Developer Tea" type="rss" xmlUrl="http://feeds.feedburner.com/DeveloperTea" htmlUrl="http://www.developertea.com" />
  </body>
</opml>
```

The resulting serverlist looked like so: 

```
http://www.developertea.com OPML_Import_2017-04-17 Developer Tea
```

The podcast download didn't work, because the url in the serverlist is the htmlUrl, not the xmlUrl which leads to the rss/atom feed. 

This simple change in a regexp fixes this.